### PR TITLE
Correct intake catalog url

### DIFF
--- a/notebooks/ocean_ssh_example.ipynb
+++ b/notebooks/ocean_ssh_example.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "import intake\n",
-    "cat = intake.Catalog('https://raw.githubusercontent.com/pangeo-data/pangeo_ocean_examples/master/catalog.yaml')\n",
+    "cat = intake.Catalog('https://raw.githubusercontent.com/pangeo-data/pangeo/master/gce/catalog.yaml')\n",
     "ds = cat.sea_surface_height.to_dask()\n",
     "ds"
    ]


### PR DESCRIPTION
This fixes the location of the intake catalog in the SSH notebook